### PR TITLE
No Notification, No Message

### DIFF
--- a/index.js
+++ b/index.js
@@ -347,18 +347,24 @@ async function isDockerContainerRunning(containerName) {
 
 // send the uptime message (and possibly ping) to the discord webhook
 async function postToDiscordWebhook(admin, message, uptimeRole) {
-    // if the admin didn't provide any message to send, bail
-    if (!message) {
-        console.log('No message was provided. Nothing will be posted to Discord.');
-        return;
-    }
     // if the webhook isn't defined, bail
     if (!DISCORD_WEBHOOK_URL) {
         console.log('DISCORD_WEBHOOK_URL not defined in environment variables. Nothing will be posted to Discord.');
         return;
     }
+    // if the admin unchecked the notification box, bail
+    if (!uptimeRole) {
+        console.log('@Uptime role box was unchecked. Nothing will be posted to Discord.');
+        return;
+    }
+    // if the admin didn't provide any message to send, bail
+    if (!message) {
+        console.log('No message was provided. Nothing will be posted to Discord.');
+        return;
+    }
 
-    const content = uptimeRole ? `<@&${UPTIME_ROLE}> ${message}` : message;
+    // build the message we'll send to Discord, using their notification syntax
+    const content = `<@&${UPTIME_ROLE}> ${message}`;
 
     const payload = {
         username: admin.global_name,


### PR DESCRIPTION
When managing the server, there is a checkbox:

    [ X ] Ping @Uptime role on Discord

This PR modifies the behavior of POST /server so that when that box is unchecked, no message will be sent to Discord.
Now the server can be brought up or down quietly.
